### PR TITLE
Map cycling of items to Q and E and directional buttons to NumPad

### DIFF
--- a/src/GameStateControls.cpp
+++ b/src/GameStateControls.cpp
@@ -212,6 +212,20 @@ void GameState::bind_controls() {
         {(int)Input::Keys::Num9, KeyFlag::Press | KeyFlag::Held},
         {Player::change_selector, SelData{world->player.get(), 8}});
 
+    // Map directions to numpad
+    key_controller->add_command(
+        {(int)Input::Keys::KeyPad8, KeyFlag::Press},
+        {Player::press_up, world->player.get()});
+    key_controller->add_command(
+        {(int)Input::Keys::KeyPad2, KeyFlag::Press},
+        {Player::press_down, world->player.get()});
+    key_controller->add_command(
+        {(int)Input::Keys::KeyPad4, KeyFlag::Press},
+        {Player::press_left, world->player.get()});
+    key_controller->add_command(
+        {(int)Input::Keys::KeyPad6, KeyFlag::Press},
+        {Player::press_right, world->player.get()});
+
     key_controller->add_command({(int)Input::Keys::Tab, KeyFlag::Release},
                                 {Player::tab_end, world->player.get()});
     key_controller->add_command(

--- a/src/GameStateControls.cpp
+++ b/src/GameStateControls.cpp
@@ -212,6 +212,14 @@ void GameState::bind_controls() {
         {(int)Input::Keys::Num9, KeyFlag::Press | KeyFlag::Held},
         {Player::change_selector, SelData{world->player.get(), 8}});
 
+    // Mouse wheel to cycle through objects
+    mouse_controller->add_command(
+        {(int)Input::MouseButtons::MWheelDown, KeyFlag::Press},
+        {Player::press_left, world->player.get()});
+    mouse_controller->add_command(
+        {(int)Input::MouseButtons::MWheelUp, KeyFlag::Press},
+        {Player::press_right, world->player.get()});
+
     // Map directions to numpad
     key_controller->add_command(
         {(int)Input::Keys::KeyPad8, KeyFlag::Press},


### PR DESCRIPTION
Useful as a way to cycle between items.
For devices like the Steam Deck, all directional buttons have been mapped to the NumPad,
so that the menu can be navigated without the use of the touch screen.